### PR TITLE
Feat/add lock session

### DIFF
--- a/system/controller/document/routes.py
+++ b/system/controller/document/routes.py
@@ -20,7 +20,7 @@ def get_documents():
     Example:
         Use the following curl command to call the endpoint with sorting by 'name':
             ```bash
-            curl -i -X GET 'http://localhost:5000/api/documents/?sort=name'
+            curl -i -X GET 'http://localhost:5000/documents?sort=name'
             ```
 
     Args:
@@ -45,7 +45,7 @@ def create_document(name, owner_id, document_status_id):
     Example:
         Use the following curl command to create a new document:
             ```bash
-            curl -i -X POST http://localhost:5000/api/documents/ \
+            curl -i -X POST http://localhost:5000/documents \
             -H "Content-Type: application/json" \
             -d '{
                 "name": "Project Proposal",
@@ -76,7 +76,7 @@ def update_document(uid, body, comments):
     Example:
         Use the following curl command to update a new document:
             ```bash
-            curl -i -X PUT http://localhost:5000/api/documents/doc1 \
+            curl -i -X PUT http://localhost:5000/documents/doc1 \
             -H "Content-Type: application/json" \
             -d '{
                 "body": "Updated body of the document.",
@@ -114,7 +114,7 @@ def get_document(uid):
     Example:
         Use the following curl command to retrieve a document by UID:
             ```bash
-            curl -i -X GET http://localhost:5000/api/documents/doc1
+            curl -i -X GET http://localhost:5000/documents/doc1
             ```
     """
     document = document_service.get_document(uid)

--- a/system/service/document_service.py
+++ b/system/service/document_service.py
@@ -109,12 +109,13 @@ class DocumentService:
                         "inlineId": comment.inline_id,
                         "text": comment.text,
                         "commentor": {
-                            "name": comment.commentor.name,
+                            "name": self.user_repo.find_user_by_id(comment.commenter_id).name,
                         }
                     }
                     for comment in document_comments
                 ]
             }
+        current_app.logger.info(f"Get NO document by uid: {uid}")
         return None
 
     def delete_document_by_uid(self, document_uid: str):

--- a/system/service/document_service.py
+++ b/system/service/document_service.py
@@ -6,6 +6,7 @@ from repo.document_repo import DocumentRepository
 from repo.user_repo import UserRepository
 from repo.audit_repo import AuditRepository
 from service.notification_service import NotificationService
+from datetime import datetime, timedelta
 
 class DocumentService:
     def __init__(self):
@@ -57,7 +58,8 @@ class DocumentService:
             uid=str(uuid4()),
             name=name,
             owner_id=owner_id,
-            document_status_id=document_status_id
+            document_status_id=document_status_id,
+            lock_session=""
         )
         new_doc = self.document_repo.create_document(document)
         return new_doc.uid
@@ -98,6 +100,15 @@ class DocumentService:
         if document:
             document_comments = self.document_repo.get_document_comment_by_document_id(document.id)
             current_app.logger.info(f"Get {len(document_comments)} comments of document (uid: {uid})")
+            if document.lock_session is not "" and document.lock_session is not None:
+                lock_session = datetime.strptime(document.lock_session, "%Y-%m-%d %H:%M:%S")
+                if lock_session + timedelta(minutes=5) > datetime.now() :
+                    current_app.logger.info(f"Document Ud: {uid} is locked by other user.")
+                    return {
+                        "state": "session is locked by other user."
+                    }
+            document.lock_session = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.document_repo.update_document(document)
             return {
                 "uid": document.uid,
                 "name": document.name,
@@ -115,9 +126,25 @@ class DocumentService:
                     for comment in document_comments
                 ]
             }
-        current_app.logger.info(f"Get NO document by uid: {uid}")
-        return None
+        current_app.logger.info(f"Can't find document by uid: {uid}")
+        return {"state": "Cant find document by uid"}
 
+    def delete_lock_session_by_uid(self, uid: str):
+        document = self.document_repo.get_document_by_uid(uid)
+        if document:
+            document.lock_session = ""
+            self.document_repo.update_document(document)
+            return {"state": "true"}
+        return {"state": "false"}
+    
+    def update_lock_session_by_uid(self, uid: str):
+        document = self.document_repo.get_document_by_uid(uid)
+        if document:
+            document.lock_session = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.document_repo.update_document(document)
+            return {"state": "true", "lock_session": document.lock_session}
+        return {"state": "false"}
+    
     def delete_document_by_uid(self, document_uid: str):
         """Delete a document from the database identified by its unique identifier (UID).
 


### PR DESCRIPTION
1. 在 GET document/UID 時會進行 lock session 檢查，如果 

  + `document的lock-session`  為空
  + `自己的session[lock session]`與 `document的lock-session` 相同
  + `自己的session[lock session]` 與 `document的lock-session` 不同，但`document的lock-session`獲取時間與當前時間差超過5分鐘

    可獲得獲取document的權限，並獲得新的lock-session，否則沒權限獲得document

2.  PUT document/UID /lock-session(不用傳參數) : 驗證`自己的session[lock session]`與 `document的lock-session` 相同後，會重新給予新的lock-session
3.  DELETE document/UID /lock-session(不用傳參數): 驗證`自己的session[lock session]`與 `document的lock-session` 相同後，會刪除該lock-session

可參閱:https://www.notion.so/Cloud_Native_API-745f36567191413dbd99a9565a3c92ff

